### PR TITLE
fix: Cmd+V clipboard paste in tmux copy-mode

### DIFF
--- a/.tmux.conf.osx
+++ b/.tmux.conf.osx
@@ -25,7 +25,7 @@ bind-key -T copy-mode-vi y send-keys -X copy-pipe "pbcopy"
 bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-no-clear "bash -c 'content=$(cat); [ -n \"$content\" ] && echo -n \"$content\" | pbcopy'"
 bind-key -T copy-mode-vi p send-keys -X cancel \; run "pbpaste | tmux load-buffer - && tmux paste-buffer"
 bind-key -T copy-mode-vi M-v send-keys -X cancel \; run "pbpaste | tmux load-buffer - && tmux paste-buffer"
-# bind-key -T root M-v run "pbpaste | tmux load-buffer - && tmux paste-buffer"
+bind-key -T root M-v run "pbpaste | tmux load-buffer - && tmux paste-buffer"
 
 bind 'C' new-window -c "#{pane_current_path}" -n "#{b:pane_current_path}";
 bind '%' split-window -h -c "#{pane_current_path}";

--- a/mac/wezterm.lua
+++ b/mac/wezterm.lua
@@ -34,6 +34,8 @@ return {
   use_ime = true,
   macos_forward_to_ime_modifier_mask = 'SHIFT|CTRL',
   keys = {
+    -- Delegate Cmd+V to tmux so paste works even in copy-mode
+    { key = 'v',     mods = 'CMD',          action = act.SendKey { key = 'v', mods = 'ALT' } },
     { key = 'v',     mods = 'ALT',          action = act.PasteFrom 'Clipboard' },
     { key = 'f',     mods = 'CTRL | SHIFT', action = act.ToggleFullScreen },
     -- shift enter to meta + enter


### PR DESCRIPTION
Cmd+V in wezterm sends raw keystrokes which tmux copy-mode interprets
as vi commands. Delegate Cmd+V to tmux via Alt+V so the M-v bindings
handle paste correctly in both copy-mode and normal mode.

https://claude.ai/code/session_01Xj31F3ZJaQALwuKHAb7Spo